### PR TITLE
Fix for Rails 4 and new AA

### DIFF
--- a/activeadmin-axlsx.gemspec
+++ b/activeadmin-axlsx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {spec}/*`.split("\n")
   s.test_files  = Dir.glob("{spec/**/*}")
 
-  s.add_runtime_dependency 'activeadmin', "~> 0.6.0"
+  s.add_runtime_dependency 'activeadmin', ">= 0.6.0"
   s.add_runtime_dependency 'axlsx'
 
   s.required_ruby_version = '>= 1.9.2'

--- a/lib/active_admin/axlsx/resource_controller_extension.rb
+++ b/lib/active_admin/axlsx/resource_controller_extension.rb
@@ -9,7 +9,7 @@ module ActiveAdmin
 
       # patching the index method to allow the xlsx format.
       def index_with_xlsx(options={}, &block)
-        index_without_xlsx(options) do |format|
+        index_without_xlsx do |format|
            format.xlsx do
             xlsx = active_admin_config.xlsx_builder.serialize(collection)
             send_data xlsx, :filename => "#{xlsx_filename}", :type => Mime::Type.lookup_by_extension(:xlsx)


### PR DESCRIPTION
index_without_xlsx(options) causes Error "wrong number of arguments" in Rails 4.
